### PR TITLE
bugfix about animation.js

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -83,6 +83,15 @@ var Animation = function () {
      */
     this.isFinished = function () { return finished; };
 
+    //noinspection JSUnusedGlobalSymbols
+    /**
+     * Is animation currentTime?
+     * @return {integer}
+     */
+    this.getTime = function () {
+        return Math.round(this.playTime * (fNum / ani.frames.length));
+    };
+
     // Private
 
     var ani = this,
@@ -94,6 +103,9 @@ var Animation = function () {
         contexts = [];
 
     var tick = function (now) {
+        if (500 < now - nextRenderTime) {
+            nextRenderTime = now;
+        }
         while (played && nextRenderTime <= now) renderFrame(now);
         if (played) requestAnimationFrame(tick);
     };
@@ -129,7 +141,7 @@ var Animation = function () {
             nextRenderTime += frame.delay;
         } else {
             played = false;
-            finished = false;
+            finished = true;
         }
     };
 };


### PR DESCRIPTION
Hello, @davidmz -san.
apng-canvas is nice solution to us.
I got a little bug, when I used this library.
1. When scrolling in mobile browsers
   apng-animation is skipped because stopped javascript. So, I reset nextRenderTime when there is a difference in the nextRenderTime and `Date.now`.
2. Finished flag
   `finished` changed to true, when `played` changed to false.

And I needed currentTime. So I added getTime function.
Thanks.
