### PR TITLE
Fix bugs about "finished" in Animation.js

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -129,7 +129,7 @@ var Animation = function () {
             nextRenderTime += frame.delay;
         } else {
             played = false;
-            finished = false;
+            finished = true;
         }
     };
 };

--- a/src/animation.js
+++ b/src/animation.js
@@ -102,6 +102,12 @@ var Animation = function () {
         var f = fNum++ % ani.frames.length;
         var frame = ani.frames[f];
 
+        if (!(ani.numPlays == 0 || fNum / ani.frames.length <= ani.numPlays)) {
+            played = false;
+            finished = true;
+            return;
+        }
+
         if (f == 0) {
             contexts.forEach(function (ctx) {ctx.clearRect(0, 0, ani.width, ani.height);});
             prevF = null;
@@ -123,14 +129,9 @@ var Animation = function () {
         }
         contexts.forEach(function (ctx) {ctx.drawImage(frame.img, frame.left, frame.top);});
 
-        if (ani.numPlays == 0 || fNum / ani.frames.length < ani.numPlays) {
-            if (nextRenderTime == 0) nextRenderTime = now;
-            while (now > nextRenderTime + ani.playTime) nextRenderTime += ani.playTime;
-            nextRenderTime += frame.delay;
-        } else {
-            played = false;
-            finished = true;
-        }
+        if (nextRenderTime == 0) nextRenderTime = now;
+        while (now > nextRenderTime + ani.playTime) nextRenderTime += ani.playTime;
+        nextRenderTime += frame.delay;
     };
 };
 


### PR DESCRIPTION
Fixed two bugs about "finished" property in Animation.js

- "finished" is always being false.
- "played" is set before last frame delay finishes.

